### PR TITLE
Pbm fix

### DIFF
--- a/general/update_pfm/Update/02_update_pfm_values.sql
+++ b/general/update_pfm/Update/02_update_pfm_values.sql
@@ -44,4 +44,4 @@ AND
 -- updated 72734
 
 -- Confirmed that 931 nulls existed in the original pbm values that were not solved by this update. 
--- This update fixed 848 pbm values that were incorrectly filled with 0 expected fatalities. Two still remain.
+-- This update fixed 848 pbm values that were incorrectly filled with 0 estimated fatalities. Two still remain.

--- a/general/update_pfm/Update/02_update_pfm_values.sql
+++ b/general/update_pfm/Update/02_update_pfm_values.sql
@@ -44,4 +44,4 @@ AND
 -- updated 72734
 
 -- Confirmed that 931 nulls existed in the original pbm values that were not solved by this update. 
--- This update fixed 848 pbm values that were incorrected filled with 0 expected fatalities. Two still remain.
+-- This update fixed 848 pbm values that were incorrectly filled with 0 expected fatalities. Two still remain.

--- a/general/update_pfm/Update/02_update_pfm_values.sql
+++ b/general/update_pfm/Update/02_update_pfm_values.sql
@@ -1,0 +1,47 @@
+-- backup values 
+UPDATE 
+    static.national_tracts
+SET 
+    outdated_pfm_values = pbm_value; 
+
+-- count total 
+SELECT 
+    COUNT(*) 
+FROM 
+    static.national_tracts;
+-- 73666 (spooky number)
+
+-- count match
+SELECT 
+    COUNT(*)
+FROM 
+    static.national_tracts n
+WHERE 
+    EXISTS( SELECT 
+                1 
+            FROM 
+                 static.pfm_corrected_predvalyearly_20220113_js j
+            WHERE 
+                j.geoid = n.geoid)
+;
+--72734, 932 fewer
+
+UPDATE 
+    static.national_tracts c
+SET 
+    pbm_value = j.predvalyearly
+FROM 
+    static.pfm_corrected_predvalyearly_20220113_js j
+WHERE 
+    c.geoid = j.geoid
+AND  
+    EXISTS( SELECT 
+                1 
+            FROM 
+                 static.pfm_corrected_predvalyearly_20220113_js j
+            WHERE 
+                j.geoid = n.geoid); 
+-- updated 72734
+
+-- Confirmed that 931 nulls existed in the original pbm values that were not solved by this update. 
+-- This update fixed 848 pbm values that were incorrected filled with 0 expected fatalities. Two still remain.

--- a/general/update_pfm/Update/load_data.R
+++ b/general/update_pfm/Update/load_data.R
@@ -1,0 +1,16 @@
+library('RPostgreSQL')
+db <-DBI::dbConnect(DBI::dbDriver(drvName = "PostgreSQL"),
+                    dbname=SSPF_AMAZON_DATABASE,
+                    host=SSPF_AMAZON_HOST_ADDRESS, 
+                    port=5432,
+                    user = SSPF_AMAZON_USERNAME ,
+                    password = SSPF_AMAZON_PASSWORD)
+
+data <- read.csv('//Users//Bikingman//Documents//GitHub//Safer-Streets-Priority-Finder//general/update_pfm//exports//pfm_corrected_predvalyearly_20220113_js.csv')
+
+dbWriteTable(db, c(glue::glue("static"),glue::glue("pfm_corrected_predvalyearly_20220113_js")),
+             value = data,
+             append = FALSE,
+             row.names = FALSE,
+             overwrite = TRUE)
+


### PR DESCRIPTION
This update fixed 848 pbm values that were incorrectly filled with 0 estimated pedestrian fatalities. Two still remain.
This has not addressed the 931 null values found in the data, of which mostly exist in Puerto Rico. 